### PR TITLE
twig/twig minimum version 3.2 required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1.3|^8.0",
         "symfony/framework-bundle": "^4.3|^5.0",
         "symfony/twig-bundle": "^4.3|^5.0",
-        "twig/twig": "^2.4|^3.0"
+        "twig/twig": "^3.2"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.4.9|^5.0.9",


### PR DESCRIPTION
Due to the addition of `registerUndefinedTokenParserCallback ` in the file `MissingExtensionSuggestorPass.php`, version 3.2 of twig/twig is also required. 
With older versions of twig/twig installed, an error is thrown: 
```
 Attempted to call an undefined method named "registerUndefinedTokenParserCallback" of class "Twig\Environment".                                         
Did you mean to call e.g. "registerUndefinedFilterCallback" or "registerUndefinedFunctionCallback"?      
```                                               