### PR TITLE
Added symfony/dependency-injection:^5.1 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^7.1.3|^8.0",
+        "symfony/dependency-injection": "^5.1",
         "symfony/framework-bundle": "^4.3|^5.0",
         "symfony/twig-bundle": "^4.3|^5.0",
         "twig/twig": "^2.4|^3.0"


### PR DESCRIPTION
After updating to `3.2.0` I get the following error (because of the usage of `service()` function):
```
Symfony\Component\ErrorHandler\Error\UndefinedFunctionError {#998
!!    #message: "Attempted to call function "service" from namespace "Symfony\Component\DependencyInjection\Loader\Configurator"."
!!    #code: 0
!!    #file: "./vendor/twig/extra-bundle/Resources/config/markdown.php"
!!    #line: 25
```
It looks like the `service()` function is introduced in https://github.com/symfony/symfony/commit/366405b93d670555079605422c5fd05cda23ee08#diff-0f4455419d7d5f79423475e597c88c6901a7d00871165ea2967da1183390cf56R100. This would make it a requirement this bundle needs a dependency on `symfony/dependency-injection:^5.1` as well? Using `symfony/dependency-injection:4.4.18` atm.