### PR TITLE
Upgrade to version 4.4 lts at least

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "php": "^7.1.3|^8.0",
-        "symfony/framework-bundle": "^4.3|^5.0|^6.0",
-        "symfony/twig-bundle": "^4.3|^5.0|^6.0",
+        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
+        "symfony/twig-bundle": "^4.4|^5.0|^6.0",
         "twig/twig": "^2.4|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Related to https://symfony.com/releases/4.3
Allow me to propose this change, even if I do not know what are your processes of upgrading ecosystems packages related to the eom/eol of main symfony repo when the lts is released

As far as i know, upgrading from vX.0|1|2|3 to vX.4 is « easy » (deprecations appart)

Feel free to close, I would be happy to know why/reasons if it is the case :)
Thanks