### PR TITLE
 add "void" as a native return type declaration

### DIFF
--- a/TwigExtraBundle.php
+++ b/TwigExtraBundle.php
@@ -17,7 +17,7 @@ use Twig\Extra\TwigExtraBundle\DependencyInjection\Compiler\MissingExtensionSugg
 
 class TwigExtraBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
```
!!  2023-04-08T19:35:15+00:00 [info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Twig\Extra\TwigExtraBundle\TwigExtraBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
```