### PR TITLE
suppress deprecation warning using explicit return annotation

### DIFF
--- a/TwigExtraBundle.php
+++ b/TwigExtraBundle.php
@@ -17,6 +17,7 @@ use Twig\Extra\TwigExtraBundle\DependencyInjection\Compiler\MissingExtensionSugg
 
 class TwigExtraBundle extends Bundle
 {
+    /** @return void */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);


### PR DESCRIPTION
> !!  2023-04-14T10:59:02+00:00 [info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Twig\Extra\TwigExtraBundle\TwigExtraBundle" now to avoid errors or add an explicit `@return` annotation to suppress this message.