### PR TITLE
suppress native return type deprecation msg

### DIFF
--- a/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
+++ b/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
@@ -18,6 +18,7 @@ use Twig\Environment;
 
 class MissingExtensionSuggestorPass implements CompilerPassInterface
 {
+    /** @return void */
     public function process(ContainerBuilder $container)
     {
         if ($container->getParameter('kernel.debug')) {

--- a/DependencyInjection/TwigExtraExtension.php
+++ b/DependencyInjection/TwigExtraExtension.php
@@ -23,6 +23,7 @@ use Twig\Extra\TwigExtraBundle\Extensions;
  */
 class TwigExtraExtension extends Extension
 {
+    /** @return void */
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));


### PR DESCRIPTION
> Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Twig\Extra\TwigExtraBundle\DependencyInjection\TwigExtraExtension" now to avoid errors or add an explicit `@return` annotation to suppress this message.
