### PR TITLE
Patch 1

### DIFF
--- a/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
+++ b/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
@@ -19,7 +19,7 @@ use Twig\Environment;
 class MissingExtensionSuggestorPass implements CompilerPassInterface
 {
     /** @return void */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->getParameter('kernel.debug')) {
             $twigDefinition = $container->getDefinition('twig');

--- a/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
+++ b/DependencyInjection/Compiler/MissingExtensionSuggestorPass.php
@@ -18,7 +18,6 @@ use Twig\Environment;
 
 class MissingExtensionSuggestorPass implements CompilerPassInterface
 {
-    /** @return void */
     public function process(ContainerBuilder $container): void
     {
         if ($container->getParameter('kernel.debug')) {

--- a/DependencyInjection/TwigExtraExtension.php
+++ b/DependencyInjection/TwigExtraExtension.php
@@ -24,7 +24,7 @@ use Twig\Extra\TwigExtraBundle\Extensions;
 class TwigExtraExtension extends Extension
 {
     /** @return void */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
         $configuration = $this->getConfiguration($configs, $container);

--- a/DependencyInjection/TwigExtraExtension.php
+++ b/DependencyInjection/TwigExtraExtension.php
@@ -23,7 +23,6 @@ use Twig\Extra\TwigExtraBundle\Extensions;
  */
 class TwigExtraExtension extends Extension
 {
-    /** @return void */
     public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));


### PR DESCRIPTION
add void-return type to functions in order to prevent depreciation message in Symfony 6.3 