### PR TITLE
Add ability to customize options injected into LeagueCommonMarkConverterFactory

### DIFF
--- a/LeagueCommonMarkConverterFactory.php
+++ b/LeagueCommonMarkConverterFactory.php
@@ -20,18 +20,20 @@ use League\CommonMark\Extension\ExtensionInterface;
 final class LeagueCommonMarkConverterFactory
 {
     private $extensions;
+    private $converterConfig;
 
     /**
      * @param ExtensionInterface[] $extensions
      */
-    public function __construct(iterable $extensions)
+    public function __construct(iterable $extensions, array $converterConfig = [])
     {
         $this->extensions = $extensions;
+        $this->converterConfig = $converterConfig;
     }
 
     public function __invoke(): CommonMarkConverter
     {
-        $converter = new CommonMarkConverter();
+        $converter = new CommonMarkConverter($this->converterConfig);
 
         foreach ($this->extensions as $extension) {
             $converter->getEnvironment()->addExtension($extension);


### PR DESCRIPTION
This way, adding custom options can be done by overriding the service in DI's config:

```yaml
services:
  Twig\Extra\TwigExtraBundle\LeagueCommonMarkConverterFactory:
    arguments:
      - !tagged_iterator { tag: twig.markdown.league_extension }
      - # custom config array for League\CommonMark\CommonMarkConverter's constructor
```