### PR TITLE
Allow to install Symfony 8 packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     ],
     "require": {
         "php": ">=8.1.0",
-        "symfony/framework-bundle": "^5.4|^6.4|^7.0",
-        "symfony/twig-bundle": "^5.4|^6.4|^7.0",
+        "symfony/framework-bundle": "^5.4|^6.4|^7.0|^8.0",
+        "symfony/twig-bundle": "^5.4|^6.4|^7.0|^8.0",
         "twig/twig": "^3.2|^4.0"
     },
     "require-dev": {
         "league/commonmark": "^2.7",
-        "symfony/phpunit-bridge": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^6.4|^7.0|^8.0",
         "twig/cache-extra": "^3.0",
         "twig/cssinliner-extra": "^3.0",
         "twig/html-extra": "^3.0",


### PR DESCRIPTION
Fixes this error:

```
 Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires twig/extra-bundle ^3.17 -> satisfiable by twig/extra-bundle[v3.17.0, ..., 3.x-dev].
    - twig/extra-bundle[v3.17.0, ..., 3.x-dev] require symfony/framework-bundle ^5.4|^6.4|^7.0 -> found symfony/framework-bundle[v5.4.0-BETA1, ..., 5.4.x-dev, v6.4.0-BETA1, ..., 6.4.x-dev, v7.0.0-BETA1, ..., 7.4.x-dev] but these were not loaded, likely because it conflicts with another require.
```