### PR TITLE
fix: Update TwigExtraExtension for Symfony 8 compatibility

### DIFF
--- a/DependencyInjection/TwigExtraExtension.php
+++ b/DependencyInjection/TwigExtraExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Twig\Extra\TwigExtraBundle\Extensions;
+use Symfony\Component\HttpKernel\Kernel;
 
 if (Kernel::MAJOR_VERSION >= 8) {
     /** @internal */

--- a/DependencyInjection/TwigExtraExtension.php
+++ b/DependencyInjection/TwigExtraExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Twig\Extra\TwigExtraBundle\Extensions;
 
-if (!method_exists(ContainerBuilder::class, 'getAutoconfiguredAttributes')) {
+if (Kernel::MAJOR_VERSION >= 8) {
     /** @internal */
     trait TwigExtraExtensionTrait
     {


### PR DESCRIPTION
There is an error if not all symfony packages are upgraded to 8.x

If i am correct `if (!method_exists(ContainerBuilder::class, 'getAutoconfiguredAttributes')) {`
checks DependencyInjection Repo.

But after `Upgrading symfony/http-kernel (v7.4.2 => v8.0.2): Extracting archive` i got an error.
DependencyInjection is still on 7.4.x